### PR TITLE
fix the discrepancy of Ensembl fasta format naming convention

### DIFF
--- a/src/prepare/customize_download.py
+++ b/src/prepare/customize_download.py
@@ -40,51 +40,55 @@ def download(release, organism):
 	# retreive the prefix of the file (based on the latest download filename)
 	gtf_file = max([f for f in os.listdir('.') if f.lower().endswith('.gtf.gz')],
                        key=os.path.getctime)
-	prefix_search = re.search('(.*).gtf', gtf_file)
+
+	prefix_search = re.search('(.*)\.gtf', gtf_file)
+
 	if(not prefix_search):
 		print("Could not find the gtf.gz file!")
 	 	sys.exit(0)
 
 	prefix = prefix_search.group(1)
+
+
 	# unzip GTF file
-	os.system("gunzip %s " % (prefix + ".gtf.gz"))
+	os.system("gunzip %s " % ("*.gtf.gz"))
 
 	# extract protein coding entries
-        gtf_origin = prefix + ".gtf"
-        gtf_protein_only_origin = prefix+".protein_coding.gtf"
-        os.system("grep 'protein_coding' %s > %s" % (gtf_origin, gtf_protein_only_origin + ".backup"))
+	gtf_origin = prefix + ".gtf"
+	gtf_protein_only_origin = prefix+".protein_coding.gtf"
+	os.system("grep 'protein_coding' %s > %s" % (gtf_origin, gtf_protein_only_origin + ".backup"))
 
-        gtf_backup = gtf_origin + ".backup"
+	gtf_backup = gtf_origin + ".backup"
 	# remove none chromosome entries (not in 1-19, X, Y, MT) from the GTF
 	os.system("grep -E '^MT|^[XY]|^[0-9]*\t' %s > %s" %
-                  (gtf_protein_only_origin + ".backup", gtf_protein_only_origin))
+				(gtf_protein_only_origin + ".backup", gtf_protein_only_origin))
 	os.system("mv %s %s" % (gtf_origin, gtf_origin + ".backup"))
 	os.system("grep -E '^MT|^[XY]|^[0-9]*\t' %s > %s" %(gtf_origin + ".backup", gtf_origin))
 
 	## GVF
 	gvf_file = organism.capitalize() + ".gvf.gz"
-	# os.system("wget %s/%s" %(gvf_dir, gvf_file))
-	# os.system("gunzip %s " %(gvf_file))
+	os.system("wget %s/%s" %(gvf_dir, gvf_file))
+	os.system("gunzip %s " %(gvf_file))
 
 	## DNA sequence
 	target = prefix + ".dna.fa"
-	os.system("wget %s/%s" %(fasta_dir, prefix+".dna.chromosome.[0-9]*.fa.gz"))
-	os.system("wget %s/%s" %(fasta_dir, prefix+".dna.chromosome.[XYWZ].fa.gz"))
-	os.system("wget %s/%s" %(fasta_dir, prefix+".dna.chromosome.MT.fa.gz"))
-	os.system("gunzip %s" %(prefix + ".dna.chromosome.*.fa.gz"))
-	os.system("cat %s >> %s" %(prefix + ".dna.chromosome.*.fa", target))
-	os.system("mkdir -p fa")
-	os.system("mv %s fa/" %(prefix + ".dna.chromosome.*.fa"))
-	os.chdir("fa")
-	# change filenames
-	fa_file = [f for f in os.listdir('.') if f.lower().endswith('.fa')]
-	for f in fa_file:
-		fa_prefix = re.search('.*.chromosome.(.*).fa', f)
-		if(fa_prefix):
-			print("mv %s %s" %(f, fa_prefix.group(1)+".fa"))
-			os.system("mv %s %s" %(f, fa_prefix.group(1)+".fa"))
-	os.chdir("..")
-        return root, gtf_origin, gtf_protein_only_origin, gvf_file,  target
+	os.system("wget %s/%s" %(fasta_dir, "*.dna.chromosome.[0-9]*.fa.gz"))
+	os.system("wget %s/%s" %(fasta_dir, "*.dna.chromosome.[XYWZ].fa.gz"))
+	os.system("wget %s/%s" %(fasta_dir, "*.dna.chromosome.MT.fa.gz"))
+	os.system("gunzip %s" %("*.dna.chromosome.*.fa.gz"))
+	os.system("cat %s >> %s" %("*.dna.chromosome.*.fa", target))
+	# os.system("mkdir -p fa")
+	# os.system("mv %s fa/" %(prefix + ".dna.chromosome.*.fa"))
+	# os.chdir("fa")
+	# # change filenames
+	# fa_file = [f for f in os.listdir('.') if f.lower().endswith('.fa')]
+	# for f in fa_file:
+	# 	fa_prefix = re.search('.*.chromosome.(.*).fa', f)
+	# 	if(fa_prefix):
+	# 		print("mv %s %s" %(f, fa_prefix.group(1)+".fa"))
+	# 		os.system("mv %s %s" %(f, fa_prefix.group(1)+".fa"))
+	# os.chdir("..")
+	return root, gtf_origin, gtf_protein_only_origin, gvf_file,  target
 
 
 def main(parser):
@@ -96,8 +100,10 @@ def main(parser):
     echo("Download Data For %s release %s" %(organism, release))
     root, gtf_file, gtf_protein_coding_file, gvf_file, fa_file = download(release, organism)
     echo("Donwload Completed")
+
     transcript_fasta, gene_fasta, transcript_fasta_pc, gene_fasta_pc = generate_fasta.generate(
         root, gtf_file, gtf_protein_coding_file, fa_file)
+
     # remove "../"
     gene_fasta = gene_fasta[3:]
     gene_fasta_pc = gene_fasta_pc[3:]


### PR DESCRIPTION
Ensembl changes the naming convention for the chromosome fasta files in the latest release by removing release number. For example, it was 'Homo_sapiens.GRCh37.74.dna.chromosome.N.fa.gz' for release 74, and 'Homo_sapiens.GRCh38.dna.chromosome.N.fa.gz' for release 76 and beyond. 

The following script takes care of this discrepancy.
