### PR TITLE
Update prepare.sh

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -7,7 +7,8 @@ export CPPFLAGS="-I$RS_HOME/lib/gflags-2.0/src/  -I$RS_HOME/lib/glog-0.3.3/src/"
 
 mkdir -p lib
 cd lib
-wget --no-check-certificate  https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.gz
+#wget --no-check-certificate  https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.gz
+wget --no-check-certificate https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz
 tar zxf protobuf-2.5.0.tar.gz
 cd protobuf-2.5.0
 ./configure --prefix=`pwd`/../../third_party/
@@ -19,23 +20,32 @@ python setup.py install
 cd ..
 cd ..
 
-pip install leveldb protobuf pyfasta
+#pip install leveldb protobuf pyfasta
+pip install leveldb protobuf pyfasta --user
 
 # install gtest
-
-wget http://googletest.googlecode.com/files/gtest-1.7.0.zip
+#wget http://googletest.googlecode.com/files/gtest-1.7.0.zip
+#unzip gtest-1.7.0.zip
+wget https://github.com/google/googletest/archive/release-1.7.0.zip
+mv release-1.7.0.zip gtest-1.7.0.zip
 unzip gtest-1.7.0.zip
 
-wget  --no-check-certificate https://gflags.googlecode.com/files/gflags-2.0.zip
+#wget  --no-check-certificate https://gflags.googlecode.com/files/gflags-2.0.zip
+wget  --no-check-certificate https://github.com/gflags/gflags/archive/v2.0.zip
+mv v2.0.zip gflags-2.0.zip
 unzip gflags-2.0.zip
 cd gflags-2.0
 ./configure
 make
 cd ..
 
-wget  --no-check-certificate https://google-glog.googlecode.com/files/glog-0.3.3.tar.gz
-tar zxf glog-0.3.3.tar.gz
-cd glog-0.3.3
+#wget  --no-check-certificate https://google-glog.googlecode.com/files/glog-0.3.3.tar.gz
+#tar zxf glog-0.3.3.tar.gz
+#cd glog-0.3.3
+wget  --no-check-certificate https://github.com/google/glog/archive/v0.3.4.tar.gz
+mv v0.3.4.tar.gz glog-0.3.4.tar.gz
+tar zxf glog-0.3.4.tar.gz
+cd glog-0.3.4
 ./configure
 make
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -29,6 +29,7 @@ pip install leveldb protobuf pyfasta --user
 wget https://github.com/google/googletest/archive/release-1.7.0.zip
 mv release-1.7.0.zip gtest-1.7.0.zip
 unzip gtest-1.7.0.zip
+mv googletest-release-1.7.0 gtest-1.7.0
 
 #wget  --no-check-certificate https://gflags.googlecode.com/files/gflags-2.0.zip
 wget  --no-check-certificate https://github.com/gflags/gflags/archive/v2.0.zip
@@ -45,7 +46,8 @@ cd ..
 wget  --no-check-certificate https://github.com/google/glog/archive/v0.3.4.tar.gz
 mv v0.3.4.tar.gz glog-0.3.4.tar.gz
 tar zxf glog-0.3.4.tar.gz
-cd glog-0.3.4
+mv glog-0.3.4 glog-0.3.3
+cd glog-0.3.3
 ./configure
 make
 


### PR DESCRIPTION
Update the broken URLs for protobuf, gtest, gflags.  Update the version of glog to 0.3.4 from 0.3.3.